### PR TITLE
Add functionality for Netlify Forms with Remix Form

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -151,7 +151,7 @@ export const loader = async () => {
 export const action: ActionFunction = async ({ request }) => {
 	// Get the formData
 	const formData = await request.formData();
-	const baseUrl = await request.url;
+	const baseUrl = request.url;
 
 	const encode = (data: Object) =>
 		Object.keys(data)

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -151,6 +151,7 @@ export const loader = async () => {
 export const action: ActionFunction = async ({ request }) => {
 	// Get the formData
 	const formData = await request.formData();
+	const baseUrl = await request.url;
 
 	const encode = (data: Object) =>
 		Object.keys(data)
@@ -211,7 +212,7 @@ export const action: ActionFunction = async ({ request }) => {
 	// Attempt to submit the Netlify form
 	try {
 		// Perform the request, 'Netlify' should handle this correctly when they host the site and in development it will just succeed.
-		const response = await fetch('/', {
+		const response = await fetch(`${baseUrl}/form-data`, {
 			method: 'POST',
 			body: encodedFormData,
 			headers: {
@@ -504,7 +505,9 @@ const Index = () => {
 					)}
 
 					<Form
+						reloadDocument
 						method='post'
+						action='/?index'
 						noValidate
 						ref={formRef}
 						aria-hidden={state === 'success'}

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -505,7 +505,6 @@ const Index = () => {
 					)}
 
 					<Form
-						reloadDocument
 						method='post'
 						action='/?index'
 						noValidate

--- a/public/form-data.html
+++ b/public/form-data.html
@@ -1,0 +1,42 @@
+<form hidden name="Contact_Me" data-netlify="true" netlify-honeypot="bot-field">
+	<input type="hidden" name="form-name" value="Contact_Me" />
+	<label className="hidden" htmlFor="bot-field">
+		Don’t fill this out if you’re human: <input name="bot-field" />
+	</label>
+
+	<label htmlFor="name" className="flex flex-col pb-4">
+		<span className="flex">
+			Name
+			<span className="text-2xl text-yellow">*</span>
+		</span>
+		<input
+			id="name"
+			type="text"
+			placeholder="Your Name goes here"
+			name="Name"
+			className="border-2 border-gray-200 p-2"
+		/>
+	</label>
+
+	<label htmlFor="email" className="flex flex-col pb-4">
+		<span className="flex"> Email Address <span className="text-2xl text-yellow">*</span> </span>
+		<input
+			id="email"
+			type="email"
+			placeholder="Your Email goes here"
+			name="EmailAddress"
+			className="border-2 border-gray-200 p-2"
+		/>
+	</label>
+
+	<label htmlFor="message" className="flex flex-col pb-4">
+		<span className="flex"> Message <span className="text-2xl text-yellow">*</span> </span>
+		<textarea
+			id="message"
+			placeholder="Your message goes here"
+			name="Message"
+			className="border-2 border-gray-200 p-2"
+		></textarea>
+	</label>
+	<button type="submit">Submit</button>
+</form>


### PR DESCRIPTION
This was an absolutely tricky solution! Definitely had a lot of bits to it and I am gonna try to walk through some of the high level things I came across.

### Static Form under `public` folder

The work between me and Nick found out that the way that Remix loads components means we have to be creative with how the form gets processed by Netlify. We add a separate html file under `public/form-data.html` (which could be named anything but what I chose for the proof of concept). This needs to match the same structure in terms of inputs and crucially must match the `name` of whatever our `form-name` will be later on within the form rendered by Remix.

### Fetch Request requires absolute path

I was STUMPED when it came down to the `Invalid URL` error you were seeing before but then I remembered I think the problem is that the server context might not know where it is being sent to. So instead we add the request URL simply because it can match the production context url making the request. After it has the full path it all works!